### PR TITLE
Fix the issue if the specified result path does not exist

### DIFF
--- a/src/Applications/RTFRevit/RevitTestExecutive.cs
+++ b/src/Applications/RTFRevit/RevitTestExecutive.cs
@@ -499,6 +499,9 @@ namespace RTF.Applications
         {
             //write to the file
             var x = new XmlSerializer(typeof(resultType));
+            var dir = Path.GetDirectoryName(resultsPath);
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
             using (var tw = XmlWriter.Create(resultsPath, new XmlWriterSettings() { Indent = true }))
             {
                 tw.WriteComment("This file represents the results of running a test suite");


### PR DESCRIPTION
@ikeough

When the result directory specified in the UI does not exist, XmlWriter will throw an exception when it attempts to construct from the directory. This submission fixes the issue by double checking whether the result directory exists, if not, it will create the directory.
