### PR TITLE
DO NOT MERGE: Enable transaction and run the test cases when the application is idle

### DIFF
--- a/src/Framework/Runner/Runner.cs
+++ b/src/Framework/Runner/Runner.cs
@@ -972,7 +972,8 @@ namespace RTF.Framework
             try
             {
                 //exclude the specified category
-                if (String.Compare(td.Category.Name, ExcludedCategory, StringComparison.OrdinalIgnoreCase) == 0)
+                if (null != td.Category &&
+                    String.Compare(td.Category.Name, ExcludedCategory, StringComparison.OrdinalIgnoreCase) == 0)
                     return;
 
                 if (!File.Exists(td.ModelPath))
@@ -1307,14 +1308,15 @@ namespace RTF.Framework
                 if (cat != null)
                 {
                     cat.Tests.Add(testData);
+                    testData.Category = cat as ICategoryData;
                 }
                 else
                 {
                     var catData = new CategoryData(category);
                     catData.Tests.Add(testData);
                     data.Assembly.Categories.Add(catData);
+                    testData.Category = catData;
                 }
-                testData.Category = cat as ICategoryData;
             }
 
             return true;


### PR DESCRIPTION
@ikeough

This submission enables transaction and also run the test cases when the application is idle. Originally the application along with the test cases are running in the main thread. As a result, the test environment is not the same as the environment when the application is used. This causes the possibility that the tests are not catching some issues in the application. Also in the case that the transaction manager is not used, a small warning or error that happens will block the test. There is a known issue for this: MAGN-4163.

This submission runs the test cases when the application is idle. A watching thread is started to monitor whether the test cases are completed. If so, it will shutdown the application. To prevent the application to be closed by the journaling script, the part which is to close the application is removed.

Currently System.Windows.Application.Current.Shutdown() is used to close the application. This is not perfect. But until a better API is found, this is the only choice.
