### PR TITLE
Add the category option to the console application

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ RevitTestFrameworkConsole.exe is a console application which allows running RTF 
       -a, --assembly[=VALUE]        The path to the test assembly.
       -r, --results[=VALUE]         The path to the results file.
       -f, --fixture[=VALUE]         The full name (with namespace) of the test fixture.
+          --category[=VALUE]        The name of the test category.
       -t, --testName[=VALUE]        The name of a test to run
       -c, --concatenate[=VALUE]     Concatenate results with existing results file.
           --revit[=VALUE]           The Revit executable.
@@ -39,10 +40,13 @@ This is the full path to the assembly that contains your tests.
 This is the full path to an .xml file that will contain the results.
 
 **--fixture** (Optional)  
-The name of a test fixture to run. If no fixture and no test names are specified, RTF will run all tests in the assembly.
+The name of a test fixture to run. If no fixture, no category and no test names are specified, RTF will run all tests in the assembly.
+
+**--category** (Optional)  
+The name of a test category to run. If no fixture, no category and no test names are specified, RTF will run all tests in the assembly.
 
 **--testName** (Optional)  
-The name of a test to run. If no test and no fixture names are specified, RTF will run all tests in the assembly.
+The name of a test to run. If no fixture, no category and no test names are specified, RTF will run all tests in the assembly.
 
 **--concatenate** (Optional)  
 Should the results from this run of RTF be added to an existing results file if one exists at the path specified. The default behavior is to replace the existing results file.

--- a/src/Applications/RevitTestFrameworkApp/Program.cs
+++ b/src/Applications/RevitTestFrameworkApp/Program.cs
@@ -78,7 +78,8 @@ namespace RTF.Applications
 
             Console.WriteLine(runner.ToString());
 
-            if (string.IsNullOrEmpty(runner.Fixture) && string.IsNullOrEmpty(runner.Test))
+            if (string.IsNullOrEmpty(runner.Fixture) && string.IsNullOrEmpty(runner.Test)
+                && string.IsNullOrEmpty(runner.Category))
             {
                 foreach (var ad in runner.Assemblies)
                 {
@@ -103,6 +104,15 @@ namespace RTF.Applications
                     runner.SetupIndividualTest(td, runner.Continuous);
                 }
             }
+            else if (!string.IsNullOrEmpty(runner.Category))
+            {
+                var cd = runner.Assemblies.SelectMany(a => a.Categories).
+                    FirstOrDefault(c => string.Compare(c.Name, runner.Category, true) == 0) as ICategoryData;
+                if (null != cd)
+                {
+                    runner.SetupCategoryTests(cd, runner.Continuous);
+                }
+            }
 
             runner.RunAllTests();
         }
@@ -118,6 +128,7 @@ namespace RTF.Applications
                 {"r:|results:", "The path to the results file.", v=>runner.Results = Path.GetFullPath(v)},
                 {"f:|fixture:", "The full name (with namespace) of the test fixture.", v => runner.Fixture = v},
                 {"t:|testName:", "The name of a test to run", v => runner.Test = v},
+                {"category:", "The name of a test category to run.", v=> runner.Category = v},
                 {"c:|concatenate:", "Concatenate results with existing results file.", v=> runner.Concat = v != null},
                 {"revit:", "The path to Revit.", v=> runner.RevitPath = v},
                 {"dry:", "Conduct a dry run.", v=> runner.DryRun = v != null},

--- a/src/Framework/Runner/Runner.cs
+++ b/src/Framework/Runner/Runner.cs
@@ -37,6 +37,7 @@ namespace RTF.Framework
         private string _testAssembly;
         private string _test;
         private string _fixture;
+        private string _category;
         private bool _isDebug;
         private string _results;
         private const string _pluginGuid = "487f9ff0-5b34-4e7e-97bf-70fbff69194f";
@@ -193,6 +194,15 @@ namespace RTF.Framework
         {
             get { return _fixture; }
             set { _fixture = value; }
+        }
+
+        /// <summary>
+        /// The name of the category to run.
+        /// </summary>
+        public string Category
+        {
+            get { return _category; }
+            set { _category = value; }
         }
 
         /// <summary>
@@ -459,6 +469,20 @@ namespace RTF.Framework
         public void SetupFixtureTests(IFixtureData fd, bool continuous = false)
         {
             foreach (var td in fd.Tests)
+            {
+                if (cancelRequested)
+                {
+                    cancelRequested = false;
+                    break;
+                }
+
+                SetupIndividualTest(td, continuous);
+            }
+        }
+
+        public void SetupCategoryTests(ICategoryData cd, bool continuous = false)
+        {
+            foreach (var td in cd.Tests)
             {
                 if (cancelRequested)
                 {


### PR DESCRIPTION
@ikeough 

This is to add an option in the console application so that we can run a specified category of test cases.

The option is called: category.

The usage is like:
-category:<category name>
