### PR TITLE
Add the option to specify whether to copy addins

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ RevitTestFrameworkConsole.exe is a console application which allows running RTF 
       -t, --testName[=VALUE]        The name of a test to run
       -c, --concatenate[=VALUE]     Concatenate results with existing results file.
           --revit[=VALUE]           The Revit executable.
+          --copyAddins[=VALUE]      Copy addins from the Revit addins folder.
       -d, --debug                   Run in debug mode.
       -h, --help                    Show this message and exit.
 
@@ -49,6 +50,9 @@ Should the results from this run of RTF be added to an existing results file if 
 
 **--revit** (Optional)  
 Specify a Revit executable to use for testing. **You should ensure that you specify the correct version of Revit and are running the correct version of RTF (See "Revit Versions" below.)**
+
+**--copyAddins** (Optional)  
+Specified whether to copy addins from the Revit addins folder to the current working directory.
 
 **--debug** (Optional)  
 Should RTF attempt to attach to a debugger?

--- a/src/Applications/RevitTestFrameworkApp/Program.cs
+++ b/src/Applications/RevitTestFrameworkApp/Program.cs
@@ -120,6 +120,8 @@ namespace RTF.Applications
                 {"t:|testName:", "The name of a test to run", v => runner.Test = v},
                 {"c:|concatenate:", "Concatenate results with existing results file.", v=> runner.Concat = v != null},
                 {"revit:", "The path to Revit.", v=> runner.RevitPath = v},
+                {"copyAddins:", "Specify whether to copy the addins from the Revit folder to the current working directory",
+                    v=> runner.CopyAddins = v != null},
                 {"dry:", "Conduct a dry run.", v=> runner.DryRun = v != null},
                 {"x:|clean:", "Cleanup journal files after test completion", v=> runner.CleanUp = v != null},
                 {"continuous:", "Run all selected tests in one Revit session.", v=> runner.Continuous = v != null},


### PR DESCRIPTION
@ikeough 

This submission adds an additional option copyAddins to specify whether to copy addins from the Revit addin folder to the current working directory. If yes, the addins will be copied and loaded when running the test framework.
