### PR TITLE
Fix MAGN-4448 We should be able to exclude category in Revit TestFrameWork

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ RevitTestFrameworkConsole.exe is a console application which allows running RTF 
       -r, --results[=VALUE]         The path to the results file.
       -f, --fixture[=VALUE]         The full name (with namespace) of the test fixture.
           --category[=VALUE]        The name of the test category.
+          --exclude[=VALUE]         The name of the test category to exclude.
       -t, --testName[=VALUE]        The name of a test to run
       -c, --concatenate[=VALUE]     Concatenate results with existing results file.
           --revit[=VALUE]           The Revit executable.
@@ -45,6 +46,10 @@ The name of a test fixture to run. If no fixture, no category and no test names 
 
 **--category** (Optional)  
 The name of a test category to run. If no fixture, no category and no test names are specified, RTF will run all tests in the assembly.
+
+**--exclude** (Optional)  
+The name of a test category to exclude. This has a higher priortiy than other settings. If a specified category is set here, any test cases
+that belongs to that category will not run.
 
 **--testName** (Optional)  
 The name of a test to run. If no fixture, no category and no test names are specified, RTF will run all tests in the assembly.

--- a/src/Applications/RevitTestFrameworkApp/Program.cs
+++ b/src/Applications/RevitTestFrameworkApp/Program.cs
@@ -129,6 +129,7 @@ namespace RTF.Applications
                 {"f:|fixture:", "The full name (with namespace) of the test fixture.", v => runner.Fixture = v},
                 {"t:|testName:", "The name of a test to run", v => runner.Test = v},
                 {"category:", "The name of a test category to run.", v=> runner.Category = v},
+                {"exclude:", "The name of a test category to exclude.", v=> runner.ExcludedCategory = v},
                 {"c:|concatenate:", "Concatenate results with existing results file.", v=> runner.Concat = v != null},
                 {"revit:", "The path to Revit.", v=> runner.RevitPath = v},
                 {"copyAddins:", "Specify whether to copy the addins from the Revit folder to the current working directory",

--- a/src/Framework/Runner/Interfaces.cs
+++ b/src/Framework/Runner/Interfaces.cs
@@ -30,6 +30,7 @@ namespace RTF.Framework
     public interface ITestData
     {
         IFixtureData Fixture { get; set; }
+        ICategoryData Category { get; set; }
         string Name { get; set; }
         bool RunDynamo { get; set; }
         string ModelPath { get; set; }

--- a/src/Framework/Runner/Runner.cs
+++ b/src/Framework/Runner/Runner.cs
@@ -38,6 +38,7 @@ namespace RTF.Framework
         private string _test;
         private string _fixture;
         private string _category;
+        private string _excludedCategory;
         private bool _isDebug;
         private string _results;
         private const string _pluginGuid = "487f9ff0-5b34-4e7e-97bf-70fbff69194f";
@@ -214,6 +215,15 @@ namespace RTF.Framework
         {
             get { return _category; }
             set { _category = value; }
+        }
+
+        /// <summary>
+        /// The name of the category to exclude.
+        /// </summary>
+        public string ExcludedCategory
+        {
+            get { return _excludedCategory; }
+            set { _excludedCategory = value; }
         }
 
         /// <summary>
@@ -517,6 +527,10 @@ namespace RTF.Framework
         {
             try
             {
+                //exclude the specified category
+                if (string.Compare(td.Category.Name, ExcludedCategory, true) == 0)
+                    return;
+
                 if (!File.Exists(td.ModelPath))
                 {
                     throw new Exception(string.Format("Specified model path: {0} does not exist.", td.ModelPath));
@@ -695,6 +709,8 @@ namespace RTF.Framework
             var sb = new StringBuilder();
             sb.AppendLine(string.Format("Assembly : {0}", TestAssembly));
             sb.AppendLine(string.Format("Fixture : {0}", Fixture));
+            sb.AppendLine(string.Format("Category : {0}", Category));
+            sb.AppendLine(string.Format("Excluded Category : {0}", ExcludedCategory));
             sb.AppendLine(string.Format("Test : {0}", Test));
             sb.AppendLine(string.Format("Results Path : {0}", Results));
             sb.AppendLine(string.Format("Timeout : {0}", Timeout));
@@ -1108,6 +1124,7 @@ namespace RTF.Framework
                     catData.Tests.Add(testData);
                     data.Assembly.Categories.Add(catData);
                 }
+                testData.Category = cat as ICategoryData;
             }
 
             return true;
@@ -1276,6 +1293,8 @@ namespace RTF.Framework
         public ObservableCollection<IResultData> ResultData { get; set; }
 
         public IFixtureData Fixture { get; set; }
+
+        public ICategoryData Category { get; set; }
 
         public TestData(IFixtureData fixture, string name, string modelPath, bool runDynamo)
         {


### PR DESCRIPTION
@ikeough

This submission adds an option to exclude test cases from a specified category to be run in the console application.

The usage is:
-exlude:<category name>

The option has higher priority than other options. If a category is set here, the test cases which belong to this category will not run.

@monikaprabhu @riteshchandawar

Please help verify this.
