### PR TITLE
Fix an issue that RTF fails to run some test cases

### DIFF
--- a/src/Framework/Runner/Runner.cs
+++ b/src/Framework/Runner/Runner.cs
@@ -972,7 +972,8 @@ namespace RTF.Framework
             try
             {
                 //exclude the specified category
-                if (String.Compare(td.Category.Name, ExcludedCategory, StringComparison.OrdinalIgnoreCase) == 0)
+                if (null != td.Category &&
+                    String.Compare(td.Category.Name, ExcludedCategory, StringComparison.OrdinalIgnoreCase) == 0)
                     return;
 
                 if (!File.Exists(td.ModelPath))
@@ -1307,14 +1308,15 @@ namespace RTF.Framework
                 if (cat != null)
                 {
                     cat.Tests.Add(testData);
+                    testData.Category = cat as ICategoryData;
                 }
                 else
                 {
                     var catData = new CategoryData(category);
                     catData.Tests.Add(testData);
                     data.Assembly.Categories.Add(catData);
+                    testData.Category = catData;
                 }
-                testData.Category = cat as ICategoryData;
             }
 
             return true;


### PR DESCRIPTION
@ikeough 

If a test case does not belong to any category, the Category property will be null. An attempt to access the property will throw an exception and the test case will not run. 

Also when the category information is read in, the first test case in the category will be set with a category of null by mistake.

This submission fixes the two errors.
