### PR TITLE
Fix issues in the console application

### DIFF
--- a/src/Applications/RevitTestFrameworkApp/Program.cs
+++ b/src/Applications/RevitTestFrameworkApp/Program.cs
@@ -79,21 +79,21 @@ namespace RTF.Applications
 
             var p = new OptionSet()
             {
-                {"dir:","The path to the working directory.", v=> runner.WorkingDirectory = Path.GetFullPath(v)},
-                {"a:|assembly:", "The path to the test assembly.", v => runner.TestAssembly = Path.GetFullPath(v)},
-                {"r:|results:", "The path to the results file.", v=>runner.Results = Path.GetFullPath(v)},
-                {"f:|fixture:", "The full name (with namespace) of the test fixture.", v => runner.Fixture = v},
-                {"t:|testName:", "The name of a test to run", v => runner.Test = v},
-                {"category:", "The name of a test category to run.", v=> runner.Category = v},
-                {"exclude:", "The name of a test category to exclude.", v=> runner.ExcludedCategory = v},
-                {"c:|concatenate:", "Concatenate results with existing results file.", v=> runner.Concat = v != null},
-                {"revit:", "The path to Revit.", v=> runner.RevitPath = v},
+                {"dir:","The path to the working directory.", v=> setupData.WorkingDirectory = Path.GetFullPath(v)},
+                {"a:|assembly:", "The path to the test assembly.", v => setupData.TestAssembly = Path.GetFullPath(v)},
+                {"r:|results:", "The path to the results file.", v=>setupData.Results = Path.GetFullPath(v)},
+                {"f:|fixture:", "The full name (with namespace) of the test fixture.", v => setupData.Fixture = v},
+                {"t:|testName:", "The name of a test to run", v => setupData.Test = v},
+                {"category:", "The name of a test category to run.", v=> setupData.Category = v},
+                {"exclude:", "The name of a test category to exclude.", v=> setupData.ExcludedCategory = v},
+                {"c:|concatenate:", "Concatenate results with existing results file.", v=> setupData.Concat = v != null},
+                {"revit:", "The path to Revit.", v=> setupData.RevitPath = v},
                 {"copyAddins:", "Specify whether to copy the addins from the Revit folder to the current working directory",
-                    v=> runner.CopyAddins = v != null},
-                {"dry:", "Conduct a dry run.", v=> runner.DryRun = v != null},
-                {"x:|clean:", "Cleanup journal files after test completion", v=> runner.CleanUp = v != null},
-                {"continuous:", "Run all selected tests in one Revit session.", v=> runner.Continuous = v != null},
-                {"d|debug", "Run in debug mode.", v=>runner.IsDebug = v != null},
+                    v=> setupData.CopyAddins = v != null},
+                {"dry:", "Conduct a dry run.", v=> setupData.DryRun = v != null},
+                {"x:|clean:", "Cleanup journal files after test completion", v=> setupData.CleanUp = v != null},
+                {"continuous:", "Run all selected tests in one Revit session.", v=> setupData.Continuous = v != null},
+                {"d|debug", "Run in debug mode.", v=>setupData.IsDebug = v != null},
                 {"h|help", "Show this message and exit.", v=> showHelp = v != null}
             };
 

--- a/src/Framework/Runner/Runner.cs
+++ b/src/Framework/Runner/Runner.cs
@@ -30,12 +30,14 @@ namespace RTF.Framework
         public string Results { get; set; }
         public string Fixture { get; set; }
         public string Category { get; set; }
+        public string ExcludedCategory { get; set; }
         public string Test { get; set; }
         public bool Concat { get; set; }
         public bool DryRun { get; set; }
         public string RevitPath { get; set; }
         public bool CleanUp { get; set; }
         public bool Continuous { get; set; }
+        public bool CopyAddins { get; set; }
         public bool IsDebug { get; set; }
         public GroupingType GroupingType { get; set; }
         public IList<RevitProduct> Products { get; set; }

--- a/src/Tests/RunnerTests/RunnerTests.csproj
+++ b/src/Tests/RunnerTests/RunnerTests.csproj
@@ -34,6 +34,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="RevitAPI">
+      <HintPath>$(REVITAPI)\RevitAPI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Microsoft.Practices.Prism">
       <HintPath>..\..\..\lib\Microsoft.Practices.Prism.dll</HintPath>
     </Reference>


### PR DESCRIPTION
@ikeough 

The console application fails when it is parsing the arguments. The reason is that the runner is still null at the time. This submission assigns the value to the setup data instead of the runner. Thus there will be no error any more.

There is also a project which fails to compile because a reference which is used is not specified. This submission will add the missing reference.
