### PR TITLE
Make it possible to support multiple categories

### DIFF
--- a/src/Framework/Runner/AssemblyLoader.cs
+++ b/src/Framework/Runner/AssemblyLoader.cs
@@ -91,15 +91,6 @@ namespace RTF.Framework
                 modelPath = Path.GetFullPath(Path.Combine(workingDirectory, relModelPath));
             }
 
-            var category = "";
-            var categoryAttrib =
-                testAttribs.FirstOrDefault(
-                    x => x.Constructor.DeclaringType.Name == "CategoryAttribute");
-            if (categoryAttrib != null)
-            {
-                category = categoryAttrib.ConstructorArguments.FirstOrDefault().Value.ToString();
-            }
-
             var runDynamoAttrib =
                 testAttribs.FirstOrDefault(x => x.Constructor.DeclaringType.Name == "RunDynamoAttribute");
 
@@ -112,20 +103,25 @@ namespace RTF.Framework
             var testData = new TestData(data, test.Name, modelPath, runDynamo);
             data.Tests.Add(testData);
 
-            if (!String.IsNullOrEmpty(category))
+            var category = string.Empty;
+            var categoryAttribs =
+                testAttribs.Where(x => x.Constructor.DeclaringType.Name == "CategoryAttribute");
+            foreach (var categoryAttrib in categoryAttribs)
             {
-                var cat = data.Assembly.Categories.FirstOrDefault(x => x.Name == category);
-                if (cat != null)
+                category = categoryAttrib.ConstructorArguments.FirstOrDefault().Value.ToString();
+                if (!String.IsNullOrEmpty(category))
                 {
-                    cat.Tests.Add(testData);
-                    testData.Category = cat as ICategoryData;
-                }
-                else
-                {
-                    var catData = new CategoryData(data.Assembly, category);
-                    catData.Tests.Add(testData);
-                    data.Assembly.Categories.Add(catData);
-                    testData.Category = catData;
+                    var cat = data.Assembly.Categories.FirstOrDefault(x => x.Name == category);
+                    if (cat != null)
+                    {
+                        cat.Tests.Add(testData);
+                    }
+                    else
+                    {
+                        var catData = new CategoryData(data.Assembly, category);
+                        catData.Tests.Add(testData);
+                        data.Assembly.Categories.Add(catData);
+                    }
                 }
             }
 

--- a/src/Framework/Runner/Interfaces.cs
+++ b/src/Framework/Runner/Interfaces.cs
@@ -43,7 +43,6 @@ namespace RTF.Framework
     public interface ITestData:IExcludable
     {
         IFixtureData Fixture { get; set; }
-        ICategoryData Category { get; set; }
         string Name { get; set; }
         bool RunDynamo { get; set; }
         string ModelPath { get; set; }

--- a/src/Framework/Runner/Runner.cs
+++ b/src/Framework/Runner/Runner.cs
@@ -1571,8 +1571,6 @@ namespace RTF.Framework
 
         public virtual IFixtureData Fixture { get; set; }
 
-        public ICategoryData Category { get; set; }
-
         public TestData(){}
 
         public TestData(IFixtureData fixture, string name, string modelPath, bool runDynamo)


### PR DESCRIPTION
@ikeough 

Before this submission, test cases which belong to multiple categories are only attributed to the first category. It seems the order of the attributes obtained from reflection is not strictly following what are defined in the source code. As a result, the test case MAGN_2576 is attributed to the Failure category in the debug build and is not attributed to the Failure category in the release build. This is causing some confusion and instability. This submission will attribute every test case to all the categories it belong to.
