### PR TITLE
Fix MAGN-5747 and MAGN-5749

### DIFF
--- a/src/Applications/RevitTestFrameworkGUI/RunnerViewModel.cs
+++ b/src/Applications/RevitTestFrameworkGUI/RunnerViewModel.cs
@@ -325,6 +325,8 @@ namespace RTF.Applications
 
             runner.Initialize();
 
+            InitializeEventHandlers();
+
             if (runner != null) return;
 
             MessageBox.Show("The runner could not be created with the specified inputs.");


### PR DESCRIPTION
<h4>Summary</h4>

If the first time the test framework GUI application is used, after the paths are set, some event handlers are not hooked correctly.

In this pull request, I am hooking up the event handler.

@ikeough 
PTAL