### PR TITLE
MAGN-7252 As a developer, I want to run Revit test cases of one assembly in one session, so that they run in less time.

### DIFF
--- a/src/Applications/RTFRevit/RTFRevit.csproj
+++ b/src/Applications/RTFRevit/RTFRevit.csproj
@@ -64,6 +64,7 @@
       <DependentUpon>NUnitResultTypes.xsd</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RevitTestClient.cs" />
     <Compile Include="RevitTestFramework.cs" />
     <Compile Include="RevitTestExecutive.cs" />
   </ItemGroup>

--- a/src/Applications/RTFRevit/RevitTestClient.cs
+++ b/src/Applications/RTFRevit/RevitTestClient.cs
@@ -36,7 +36,7 @@ namespace RTF.Applications
                 return Result.Failed;
             }
 
-            ipAddress = IPAddress.Parse("127.0.0.1");
+            ipAddress = IPAddress.Parse(CommonData.LocalIPAddress);
             endPoint = new IPEndPoint(ipAddress, iPort);
             clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 

--- a/src/Applications/RTFRevit/RevitTestClient.cs
+++ b/src/Applications/RTFRevit/RevitTestClient.cs
@@ -53,12 +53,11 @@ namespace RTF.Applications
         /// <returns></returns>
         private bool ReadDataFromJournal(IDictionary<string, string> dataMap)
         {
-            if (!dataMap.ContainsKey("Port"))
+            string strPort;
+            if (!dataMap.TryGetValue("Port", out strPort))
             {
                 return false;
             }
-
-            string strPort = dataMap["Port"];
 
             if (!int.TryParse(strPort, out iPort))
             {

--- a/src/Applications/RTFRevit/RevitTestClient.cs
+++ b/src/Applications/RTFRevit/RevitTestClient.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using RTF.Framework;
+
+namespace RTF.Applications
+{
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    [Journaling(JournalingMode.UsingCommandData)]
+    public class RTFClientStartCmd : IExternalCommand
+    {
+        private static int iPort = 0;
+        private static Socket clientSocket;
+        private static IPAddress ipAddress;
+        private static IPEndPoint endPoint;
+
+        /// <summary>
+        /// The entry point when the command runs. This command will try to connect to localhost
+        /// at a port passed in through the journaling data.
+        /// </summary>
+        /// <param name="cmdData"></param>
+        /// <param name="message"></param>
+        /// <param name="elements"></param>
+        /// <returns></returns>
+        public Result Execute(ExternalCommandData cmdData, ref string message, ElementSet elements)
+        {
+            if (!ReadDataFromJournal(cmdData.JournalData))
+            {
+                message = "The port is not given or is in a bad format!";
+                return Result.Failed;
+            }
+
+            ipAddress = IPAddress.Parse("127.0.0.1");
+            endPoint = new IPEndPoint(ipAddress, iPort);
+            clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+            clientSocket.Connect(endPoint);
+            NotifyClientStarted();
+
+            return Result.Succeeded;
+        }
+
+        /// <summary>
+        /// Read the port data from the journal data
+        /// </summary>
+        /// <param name="dataMap"></param>
+        /// <returns></returns>
+        private bool ReadDataFromJournal(IDictionary<string, string> dataMap)
+        {
+            if (!dataMap.ContainsKey("Port"))
+            {
+                return false;
+            }
+
+            string strPort = dataMap["Port"];
+
+            if (!int.TryParse(strPort, out iPort))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Send a control message to the server to say that the client has started
+        /// </summary>
+        private static void NotifyClientStarted()
+        {
+            if (clientSocket != null)
+            {
+                ControlMessage msg = new ControlMessage(ControlType.NotificationOfStart);
+                SendMessage(msg);
+            }
+        }
+
+        /// <summary>
+        /// Send a control message to the server to say that the client has ended
+        /// </summary>
+        private static void NotifyClientEnded()
+        {
+            if (clientSocket != null)
+            {
+                ControlMessage msg = new ControlMessage(ControlType.NotificationOfEnd);
+                SendMessage(msg);
+            }
+        }
+
+        /// <summary>
+        /// When the client application has completed running, this function is called
+        /// to shutdown client
+        /// </summary>
+        public static void ShutdownClient()
+        {
+            if (clientSocket != null)
+            {
+                NotifyClientEnded();
+                clientSocket.Shutdown(SocketShutdown.Both);
+                clientSocket.Close();
+                clientSocket = null;
+                iPort = 0;
+            }
+        }
+
+        /// <summary>
+        /// Send the test name in a fixture (of a given name) to the server
+        /// </summary>
+        /// <param name="testName"></param>
+        /// <param name="fixtureName"></param>
+        public static void SendTestInformation(string testName, string fixtureName)
+        {
+            if (clientSocket != null)
+            {
+                DataMessage msg = new DataMessage(testName, fixtureName);
+                SendMessage(msg);
+            }
+        }
+
+        /// <summary>
+        /// Send a message to the server. At the beginning of the message, there are 4 bytes to
+        /// identify the message length
+        /// </summary>
+        /// <param name="msg"></param>
+        private static void SendMessage(Message msg)
+        {
+            RTFClientStartCmd.ClientSocket.Send(MessageHelper.AddHeader(Message.ToBytes(msg)));
+        }
+
+        /// <summary>
+        /// The client socket
+        /// </summary>
+        public static Socket ClientSocket
+        {
+            get
+            {
+                return clientSocket;
+            }
+        }
+    }
+
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    [Journaling(JournalingMode.UsingCommandData)]
+    public class RTFClientEndCmd : IExternalCommand
+    {
+        /// <summary>
+        /// This command will shutdown the client socket
+        /// </summary>
+        /// <param name="cmdData"></param>
+        /// <param name="message"></param>
+        /// <param name="elements"></param>
+        /// <returns></returns>
+        public Result Execute(ExternalCommandData cmdData, ref string message, ElementSet elements)
+        {
+            RTFClientStartCmd.ShutdownClient();
+
+            return Result.Succeeded;
+        }
+    }
+}

--- a/src/Applications/RTFRevit/RevitTestExecutive.cs
+++ b/src/Applications/RTFRevit/RevitTestExecutive.cs
@@ -427,6 +427,9 @@ namespace RTF.Applications
 
         private testcaseType RunTest(TestMethod t, MethodInfo[] setupMethods = null)
         {
+            //Send information about the test case to be run to the server
+            RTFClientStartCmd.SendTestInformation(t.TestName.Name, fixtureName);
+
             TestFilter filter = new NameFilter(t.TestName);
 
             var result = t.Run(new TestListener(), filter);

--- a/src/Applications/RevitTestFrameworkApp/Program.cs
+++ b/src/Applications/RevitTestFrameworkApp/Program.cs
@@ -33,8 +33,10 @@ namespace RTF.Applications
                 return;
             }
 
+            runner.StartServer();
             runner.SetupTests();
             runner.RunAllTests();
+            runner.EndServer();
         }
     }
 }

--- a/src/Applications/RevitTestFrameworkGUI/Converters.cs
+++ b/src/Applications/RevitTestFrameworkGUI/Converters.cs
@@ -85,7 +85,9 @@ namespace RTF.Applications
                 case TestStatus.None:
                     return Brushes.Transparent;
                 case TestStatus.Cancelled:
-                    return  new SolidColorBrush(Colors.DarkGray);
+                    return new SolidColorBrush(Colors.DarkGray);
+                case TestStatus.TimedOut:
+                    return new SolidColorBrush(Colors.Orange);
                 case TestStatus.Error:
                     return new SolidColorBrush(Colors.OrangeRed);
                 case TestStatus.Failure:

--- a/src/Applications/RevitTestFrameworkGUI/RunnerViewModel.cs
+++ b/src/Applications/RevitTestFrameworkGUI/RunnerViewModel.cs
@@ -518,8 +518,10 @@ namespace RTF.Applications
         {
             IsRunning = true;
 
+            runner.StartServer();
             runner.SetupTests();
             runner.RunAllTests();
+            runner.EndServer();
 
             IsRunning = false;
         }

--- a/src/Framework/RevitTestFramework/CommonData.cs
+++ b/src/Framework/RevitTestFramework/CommonData.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace RTF.Framework
+{
+    public class CommonData
+    {
+        const string strLocalIPAddress = "127.0.0.1";
+        public static string LocalIPAddress
+        {
+            get
+            {
+                return strLocalIPAddress;
+            }
+        }
+    }
+}

--- a/src/Framework/RevitTestFramework/Messages.cs
+++ b/src/Framework/RevitTestFramework/Messages.cs
@@ -1,0 +1,354 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
+using System.Threading;
+
+namespace RTF.Framework
+{
+    /// <summary>
+    /// An utility class for deserialising messages
+    /// </summary>
+    class MessageBinder : SerializationBinder
+	{
+	    public override System.Type BindToType(string assemblyName, string typeName)
+	    {
+	        var result = AppDomain.CurrentDomain.GetAssemblies()
+	            .Where(a => !a.IsDynamic)
+                .Where(a => string.CompareOrdinal(a.FullName, assemblyName) == 0)
+	            .SelectMany(a => a.GetTypes())
+	            .FirstOrDefault(t => string.CompareOrdinal(t.FullName, typeName) == 0);
+	
+	        return result;
+	    }
+	}
+
+    /// <summary>
+    /// The base class for all message classes. It has an ID which will
+    /// increase automatically whenever a new message is created
+    /// </summary>
+    [Serializable]
+    public class Message : ISerializable
+    {
+        static long currentID = 0;
+
+        public Message()
+        {
+            MessageID = Interlocked.Increment(ref currentID);
+        }
+
+        public Message(SerializationInfo info, StreamingContext context)
+        {
+            MessageID = (long)info.GetValue("MessageID", MessageID.GetType());
+        }
+
+        public long MessageID
+        {
+            get;
+            private set;
+        }
+
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("MessageID", MessageID);
+        }
+
+        public static byte[] ToBytes(Message message)
+        {
+            IFormatter formatter = new BinaryFormatter();
+            using (MemoryStream stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, message);
+                return stream.ToArray();
+            }
+        }
+
+        public static Message FromBytes(byte[] bytes)
+        {
+            try
+            {
+                IFormatter formatter = new BinaryFormatter();
+                formatter.Binder = new MessageBinder();
+                using (MemoryStream stream = new MemoryStream(bytes))
+                {
+                    return (Message)formatter.Deserialize(stream);
+                }
+            }
+            catch(Exception e)
+            {
+                string msg = e.Message;
+                return null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// This is the class for data messages which contain information for
+    /// running test cases
+    /// </summary>
+    [Serializable]
+    public class DataMessage : Message
+    {
+        public DataMessage(string testCaseName, string fixtureName)
+        {
+            TestCaseName = testCaseName;
+            FixtureName = fixtureName;
+        }
+
+        public DataMessage(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            TestCaseName = (string)info.GetValue("TestCaseName", typeof(string));
+            FixtureName = (string)info.GetValue("FixtureName", typeof(string));
+        }
+
+        public string TestCaseName
+        {
+            get;
+            set;
+        }
+
+        public string FixtureName
+        {
+            get;
+            set;
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue("TestCaseName", TestCaseName);
+            info.AddValue("FixtureName", FixtureName);
+        }
+    }
+
+    /// <summary>
+    /// This is the class for control messages which contain information to
+    /// identify the status of the client
+    /// </summary>
+    [Serializable]
+    public class ControlMessage : Message
+    {
+        public ControlMessage(ControlType type)
+        {
+            Type = type;
+        }
+
+        public ControlMessage(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            Type = (ControlType)info.GetValue("ControlType", typeof(ControlType));
+        }
+
+        public ControlType Type
+        {
+            get;
+            set;
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue("ControlType", Type);
+        }
+    }
+
+    [Serializable]
+    public enum ControlType
+    {
+        NotificationOfStart = 0,
+        NotificationOfEnd = 1
+    }
+
+    /// <summary>
+    /// This is an helper class to prepend a header before a given message
+    /// </summary>
+    public class MessageHelper
+    {
+        /// <summary>
+        /// Prepend a 4 byte array which stores the length of the input array.
+        /// NOTE that the length will not count in the 4 bytes to store the length itself
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        public static byte[] AddHeader(byte[] bytes)
+        {
+            int len = bytes.Length;
+            byte[] header = BitConverter.GetBytes(len);
+            var result = header.Concat(bytes);
+            return result.ToArray();
+        }
+    }
+
+    /// <summary>
+    /// A buffer to buffer incoming bytes arrays and include function to 
+    /// deserialise messages from the buffer
+    /// </summary>
+    public class MessageBuffer
+    {
+        List<byte[]> bytesList;
+
+        public MessageBuffer(byte[] bytes)
+        {
+            bytesList = new List<byte[]>();
+            bytesList.Add(bytes);
+        }
+
+        public void Add(byte[] bytes)
+        {
+            bytesList.Add(bytes);
+        }
+
+        /// <summary>
+        /// This will check the buffer to say if it contains bytes for a complete message.
+        /// If so, it will return a message converted from the bytes.
+        /// It may be possible that one byte array contains bytes more than one message or
+        /// several byte arrays together can generate one message. For these cases, one array
+        /// may be cut or arrays may be joined to a byte array which can be converted to a
+        /// message
+        /// </summary>
+        /// <returns></returns>
+        public Message GetMessage()
+        {
+            // Return null if nothing is buffered
+            int count = bytesList.Count;
+            if (count == 0)
+            {
+                return null;
+            }
+
+            // Return null if there are buffered bytes, but they are not
+            // enough for a complete message
+            var msgBytes = bytesList.ElementAt(0);
+            int msgSize = BitConverter.ToInt32(msgBytes, 0);
+            int availableSize = GetSizeInByte();
+            if (availableSize < msgSize + 4)
+            {
+                return null;
+            }
+
+            bytesList.RemoveAt(0);
+            int size = msgBytes.Length;
+            // Bytes are not enough
+            if (size < msgSize + 4)
+            {
+                msgBytes = msgBytes.Skip(4).ToArray();
+                while (size < msgSize + 4)
+                {
+                    var nextBytes = bytesList.ElementAt(0);
+                    bytesList.RemoveAt(0);
+                    size += nextBytes.Length;
+                    if (size < msgSize + 4)
+                    {
+                        // Bytes are not enough
+                        msgBytes = msgBytes.Concat(nextBytes).ToArray();
+                        continue;
+                    }
+                    else if (size == msgSize + 4)
+                    {
+                        // Bytes are exactly enough
+                        msgBytes = msgBytes.Concat(nextBytes).ToArray();
+                        break;
+                    }
+                    else
+                    {
+                        // Bytes are more than requried
+                        int countOfBytes = msgSize + 4 - size + nextBytes.Length;
+                        msgBytes = msgBytes.Concat(nextBytes.Take(countOfBytes)).ToArray();
+                        nextBytes = nextBytes.Skip(countOfBytes).ToArray();
+                        bytesList.Insert(0, nextBytes);
+                        break;
+                    }
+                }
+            }
+            else if (size == msgSize + 4)
+            {
+                // Bytes are exactly enough
+                msgBytes = msgBytes.Skip(4).ToArray();
+            }
+            else
+            {
+                // Bytes are more than requried
+                int countOfBytes = msgSize + 4;
+                var nextBytes = msgBytes;
+                msgBytes = msgBytes.Skip(4).Take(msgSize).ToArray();
+                nextBytes = nextBytes.Skip(countOfBytes).ToArray();
+                bytesList.Insert(0, nextBytes);
+            }
+
+
+            return Message.FromBytes(msgBytes);
+        }
+
+        /// <summary>
+        /// Get the size of buffered bytes
+        /// </summary>
+        /// <returns></returns>
+        private int GetSizeInByte()
+        {
+            int size = 0;
+            int count = bytesList.Count;
+            for (int i = 0; i < count; ++i)
+            {
+                size += bytesList.ElementAt(i).Length;
+            }
+            return size;
+        }
+    }
+
+    public enum MessageStatus
+    {
+        Success = 0,
+        TimedOut = 1,
+        LostMessages = 2,
+        OtherError = 3
+    }
+
+    /// <summary>
+    /// A class to store the resultant message and the status of the communication.
+    /// </summary>
+    public class MessageResult
+    {
+        static long prevMessageID = -1;
+        public static long PrevMessageID
+        {
+            get
+            {
+                return prevMessageID;
+            }
+            set
+            {
+                prevMessageID = value;
+            }
+        }
+
+        Message message;
+        public Message Message
+        {
+            get
+            {
+                return message;
+            }
+            set
+            {
+                message = value;
+                if (message != null)
+                {
+                    if (message.MessageID == PrevMessageID + 1)
+                    {
+                        PrevMessageID++;
+                        Status = MessageStatus.Success;
+                    }
+                }
+            }
+        }
+
+        public MessageStatus Status
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/Framework/RevitTestFramework/RevitTestFrameworkTypes.csproj
+++ b/src/Framework/RevitTestFramework/RevitTestFrameworkTypes.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <Compile Include="Attributes.cs" />
     <Compile Include="AssemblyResolver.cs" />
+    <Compile Include="CommonData.cs" />
     <Compile Include="IRTFSetup.cs" />
     <Compile Include="Messages.cs" />
     <Compile Include="TestListener.cs" />

--- a/src/Framework/RevitTestFramework/RevitTestFrameworkTypes.csproj
+++ b/src/Framework/RevitTestFramework/RevitTestFrameworkTypes.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Attributes.cs" />
     <Compile Include="AssemblyResolver.cs" />
     <Compile Include="IRTFSetup.cs" />
+    <Compile Include="Messages.cs" />
     <Compile Include="TestListener.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Framework/Runner/DataTypes.cs
+++ b/src/Framework/Runner/DataTypes.cs
@@ -426,6 +426,9 @@ namespace RTF.Framework
         [XmlIgnore]
         public virtual IFixtureData Fixture { get; set; }
 
+        [XmlIgnore]
+        public bool Completed { get; set; }
+
         public TestData() { }
 
         public TestData(IFixtureData fixture, string name, string modelPath, bool runDynamo)

--- a/src/Framework/Runner/Interfaces.cs
+++ b/src/Framework/Runner/Interfaces.cs
@@ -53,6 +53,7 @@ namespace RTF.Framework
         TestStatus TestStatus { get; set; }
         ObservableCollection<IResultData> ResultData { get; set; }
         string JournalPath { get; set; }
+        bool Completed { get; set; }
     }
 
     public interface IResultData: INotifyPropertyChanged

--- a/src/Framework/Runner/RevitTestServer.cs
+++ b/src/Framework/Runner/RevitTestServer.cs
@@ -49,7 +49,7 @@ namespace RTF.Framework
         /// <param name="timeout"></param>
         public void Start(int timeout)
         {
-            IPAddress ipAddress = IPAddress.Parse("127.0.0.1");
+            IPAddress ipAddress = IPAddress.Parse(CommonData.LocalIPAddress);
             serverSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             serverSocket.Bind(new IPEndPoint(ipAddress, 0));
 
@@ -160,7 +160,8 @@ namespace RTF.Framework
             {
                 handlerSocket = serverSocket.Accept();
                 var endPoint = handlerSocket.RemoteEndPoint as IPEndPoint;
-                if (endPoint != null && string.CompareOrdinal(endPoint.Address.ToString(), "127.0.0.1") == 0)
+                if (endPoint != null && 
+                    string.CompareOrdinal(endPoint.Address.ToString(), CommonData.LocalIPAddress) == 0)
                 {
                     break;
                 }

--- a/src/Framework/Runner/RevitTestServer.cs
+++ b/src/Framework/Runner/RevitTestServer.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Xml.Serialization;
+using Autodesk.RevitAddIns;
+using Dynamo.NUnit.Tests;
+using Microsoft.Practices.Prism;
+using NDesk.Options;
+
+namespace RTF.Framework
+{
+    public class RevitTestServer
+    {
+        private Socket serverSocket;
+        private Socket handlerSocket;
+        private int iPort;
+
+        private static RevitTestServer instance;
+        private static readonly Object mutex = new Object();
+        private static MessageBuffer buffer;
+        private static int receiveTimeout;
+
+        /// <summary>
+        /// A singleton instance
+        /// </summary>
+        public static RevitTestServer Instance
+        {
+            get
+            {
+                lock (mutex)
+                {
+                    return instance ?? (instance = new RevitTestServer());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Start the server at localhost
+        /// </summary>
+        /// <param name="timeout"></param>
+        public void Start(int timeout)
+        {
+            IPAddress ipAddress = IPAddress.Parse("127.0.0.1");
+            serverSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            serverSocket.Bind(new IPEndPoint(ipAddress, 0));
+
+            IPEndPoint endPoint = serverSocket.LocalEndPoint as IPEndPoint;
+            iPort = endPoint.Port;
+
+            serverSocket.Listen(1);
+            receiveTimeout = timeout;
+        }
+
+        /// <summary>
+        /// End the server
+        /// </summary>
+        public void End()
+        {
+            if (handlerSocket != null)
+            {
+                handlerSocket.Close();
+                handlerSocket = null;
+            }
+            if (serverSocket != null)
+            {
+                serverSocket.Close();
+                serverSocket = null;
+            }
+        }
+
+        /// <summary>
+        /// Close the working socket and also reset the message ID
+        /// </summary>
+        public void ResetWorkingSocket()
+        {
+            if (handlerSocket != null)
+            {
+                handlerSocket.Close();
+                handlerSocket = null;
+            }
+            MessageResult.PrevMessageID = -1;
+        }
+
+        /// <summary>
+        /// This will try to accept a connection from localhost and receive a packet.
+        /// It will then buffer the packet and try to create a message.
+        /// </summary>
+        /// <returns></returns>
+        public MessageResult GetNextMessageResult()
+        {
+            MessageResult result = new MessageResult();
+            if (handlerSocket == null)
+            {
+                handlerSocket = AcceptLocalConnection();
+                handlerSocket.ReceiveTimeout = receiveTimeout;
+            }
+
+            if (buffer != null)
+            {
+                var msg = buffer.GetMessage();
+                if (msg != null)
+                {
+                    result.Message = msg;
+                    return result;
+                }
+            }
+
+            var bytes = new byte[1024];
+            int size = 0;
+            try
+            {
+                size = handlerSocket.Receive(bytes, 1024, SocketFlags.None);
+            }
+            catch (SocketException e)
+            {
+                if (e.SocketErrorCode == SocketError.TimedOut)
+                {
+                    result.Status = MessageStatus.TimedOut;
+                    return result;
+                }
+                else
+                {
+                    result.Status = MessageStatus.OtherError;
+                    return result;
+                }
+            }
+            if (size > 0)
+            {
+                if (buffer == null)
+                {
+                    buffer = new MessageBuffer(bytes.Take(size).ToArray());
+                }
+                else
+                {
+                    buffer.Add(bytes.Take(size).ToArray());
+                }
+                result.Message = buffer.GetMessage();
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// To accept a connection from localhost only
+        /// </summary>
+        /// <returns></returns>
+        private Socket AcceptLocalConnection()
+        {
+            Socket handlerSocket = null;
+            while (true)
+            {
+                handlerSocket = serverSocket.Accept();
+                var endPoint = handlerSocket.RemoteEndPoint as IPEndPoint;
+                if (endPoint != null && string.CompareOrdinal(endPoint.Address.ToString(), "127.0.0.1") == 0)
+                {
+                    break;
+                }
+                handlerSocket.Close();
+            }
+            return handlerSocket;
+        }
+
+        protected Socket ServerSocket
+        {
+            get
+            {
+                return serverSocket;
+            }
+        }
+
+        /// <summary>
+        /// The port number for the server to be connected to
+        /// </summary>
+        public int Port
+        {
+            get
+            {
+                return iPort;
+            }
+        }
+    }
+}

--- a/src/Framework/Runner/Runner.cs
+++ b/src/Framework/Runner/Runner.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
+using System.Xml;
 using System.Xml.Serialization;
 using Autodesk.RevitAddIns;
 using Dynamo.NUnit.Tests;
@@ -26,7 +28,7 @@ namespace RTF.Framework
     /// </summary>
     [Serializable]
     [XmlRoot]
-    public class Runner : IRunner, IDisposable
+    public partial class Runner : IRunner, IDisposable
     {
         #region events
 
@@ -42,6 +44,10 @@ namespace RTF.Framework
 
         private const string _pluginGuid = "487f9ff0-5b34-4e7e-97bf-70fbff69194f";
         private const string _pluginClass = "RTF.Applications.RevitTestFramework";
+        private const string _clientStartPluginGuid = "8F372D6C-ECAA-4669-939E-2CD21C1F1E70";
+        private const string _clientStartPluginClass = "RTF.Applications.RTFClientStartCmd";
+        private const string _clientEndPluginGuid = "7CF281FA-D8C0-499E-AA60-7A1CF582129F";
+        private const string _clientEndPluginClass = "RTF.Applications.RTFClientEndCmd";
         private const string _appGuid = "c950020f-3da0-4e48-ab82-5e30c3f4b345";
         private const string _appClass = "RTF.Applications.RevitTestFrameworkExternalApp";
         private string _workingDirectory;
@@ -66,6 +72,7 @@ namespace RTF.Framework
         private GroupingType groupingType = GroupingType.Fixture;
         private List<SelectionHint> selectionHints = new List<SelectionHint>(); 
         private List<string> additionalResolutionDirectories = new List<string>();
+        private List<ITestData> completedTestCases = new List<ITestData>();
  
         #endregion
 
@@ -79,6 +86,26 @@ namespace RTF.Framework
         internal static string PluginClass
         {
             get { return _pluginClass; }
+        }
+
+        internal static string ClientStartPluginGuid
+        {
+            get { return _clientStartPluginGuid; }
+        }
+
+        internal static string ClientStartPluginClass
+        {
+            get { return _clientStartPluginClass; }
+        }
+
+        internal static string ClientEndPluginGuid
+        {
+            get { return _clientEndPluginGuid; }
+        }
+
+        internal static string ClientEndPluginClass
+        {
+            get { return _clientEndPluginClass; }
         }
 
         #endregion
@@ -408,6 +435,23 @@ namespace RTF.Framework
 
         #region public methods
 
+        public void StartServer()
+        {
+            // If dryRun is true, the server won't be started
+            if (continuous && !dryRun)
+            {
+                RevitTestServer.Instance.Start(Timeout);
+            }
+        }
+
+        public void EndServer()
+        {
+            if (continuous && !dryRun)
+            {
+                RevitTestServer.Instance.End();
+            }
+        }
+
         /// <summary>
         /// Setup all tests, creating journal files, the addin file,
         /// and copying the addins from the addins folder on the
@@ -416,24 +460,14 @@ namespace RTF.Framework
         /// <param name="parameter"></param>
         public void SetupTests()
         {
-            journalInitialized = false;
-            journalFinished = false;
-
             var runnable = GetRunnableTests();
-            foreach (var test in runnable)
-            {
-                SetupIndividualTest(test, Continuous);
-            }
-
-            if (continuous && !journalFinished)
-            {
-                FinishJournal(BatchJournalPath);
-            }
 
             if (!File.Exists(AddinPath))
             {
                 CreateAddin(AddinPath, AssemblyPath);
             }
+
+            CreateJournalForTestCases(runnable);
 
             // Copy addins from the Revit addin folder to the current working directory
             // so that they can be loaded.
@@ -449,6 +483,25 @@ namespace RTF.Framework
                         CopiedAddins.Add(fileName);
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Create journal files for a given set of test cases
+        /// </summary>
+        /// <param name="runnableTests"></param>
+        private void CreateJournalForTestCases(IEnumerable<ITestData> runnableTests)
+        {
+            journalInitialized = false;
+            journalFinished = false;
+            foreach (var test in runnableTests)
+            {
+                SetupIndividualTest(test, Continuous);
+            }
+
+            if (continuous && !journalFinished)
+            {
+                FinishJournal(BatchJournalPath);
             }
         }
 
@@ -971,7 +1024,15 @@ namespace RTF.Framework
             Console.WriteLine();
         }
 
-        private void ProcessBatchTests(string journalPath)
+        /// <summary>
+        /// Run tests through only on journal file.
+        /// There may be one test case to cause the running process hang.
+        /// Then the journal file will be recreated based on the remaining test cases
+        /// and this function will be called for the new journaling file.
+        /// </summary>
+        /// <param name="journalPath"></param>
+        /// <param name="firstCall"></param>
+        private void ProcessBatchTests(string journalPath, bool firstCall = true)
         {
             var startInfo = new ProcessStartInfo()
             {
@@ -984,15 +1045,159 @@ namespace RTF.Framework
             Console.WriteLine("Running {0}", journalPath);
             var process = new Process { StartInfo = startInfo };
             process.Start();
-
-            var timedOut = false;
-
-            process.WaitForExit();
-
-            if (!timedOut)
+            
+            if (!WaitForTestsToComplete(process))
             {
+                var tests = GetRunnableTests();
+                var remainingTests = tests.Where(x => !x.Completed);
+                if (remainingTests.Any())
+                {
+                    CreateJournalForTestCases(remainingTests);
+                    ProcessBatchTests(journalPath, false);
+                }
+            }
+
+            if (firstCall)
+            {
+                // If there are any test cases which are timed out, write them to the result file
+                var runnableTests = GetRunnableTests();
+                var timedoutTests = runnableTests.Where(x => x.TestStatus == TestStatus.TimedOut);
+                if (timedoutTests.Any())
+                {
+                    WriteTestResultForTestCases(timedoutTests, Results, TestAssembly);
+                }
+
                 OnTestComplete(GetRunnableTests());
             }
+        }
+
+        /// <summary>
+        /// Wait for the process to complete the test cases.
+        /// If the result is true, this means that all the tests have completed or the test has been cancelled.
+        /// If the result is false, this means tests have not completed and need to start a new process to
+        /// continue running the remaining test cases.
+        /// </summary>
+        /// <param name="process"></param>
+        /// <returns></returns>
+        private bool WaitForTestsToComplete(Process process)
+        {
+            Stopwatch watch = new Stopwatch();
+            watch.Start();
+            List<string> completedTestCaseNames = new List<string>();
+            string runningTestCaseName = string.Empty;
+            string runningFixtureName = string.Empty;
+            ITestData runningTestCase = null;
+            while (true)
+            {
+                MessageResult msgResult = RevitTestServer.Instance.GetNextMessageResult();
+                if (watch.ElapsedMilliseconds > Timeout || msgResult.Status != MessageStatus.Success)
+                {
+                    // If the test case has timed out or there are errors when getting the next message
+                    if (process != null && !(process.HasExited))
+                    {
+                        process.Kill();
+                    }
+                    RevitTestServer.Instance.ResetWorkingSocket();
+                    if (runningTestCase != null)
+                    {
+                        runningTestCase.Completed = true;
+                        runningTestCase.TestStatus = TestStatus.TimedOut;
+                        OnTestTimedOut(runningTestCase);
+                    }
+                    return false;
+                }
+                else if (cancelRequested)
+                {
+                    // If the cancel button has been clicked
+                    cancelRequested = false;
+                    if (process != null && !(process.HasExited))
+                    {
+                        process.Kill();
+                    }
+                    RevitTestServer.Instance.ResetWorkingSocket();
+                    Console.WriteLine("Test is cancelled");
+                    return true;
+                }
+
+                var ctrlMessage = msgResult.Message as ControlMessage;
+                var dataMessage = msgResult.Message as DataMessage;
+
+                if (ctrlMessage != null || dataMessage != null)
+                {
+                    if (!string.IsNullOrEmpty(runningTestCaseName))
+                    {
+                        completedTestCaseNames.Add(runningTestCaseName);
+                        if (runningTestCase != null)
+                        {
+                            runningTestCase.Completed = true;
+                        }
+                    }
+                }
+
+                if (ctrlMessage != null)
+                {
+                    if (ctrlMessage.Type == ControlType.NotificationOfEnd)
+                    {
+                        // Wait for the process to exit so that the temporary journaling files
+                        // can be deleted successfully in the cleanup stage later
+                        process.WaitForExit();
+                        return true;
+                    }
+                }
+
+                if (dataMessage != null)
+                {
+                    runningTestCaseName = dataMessage.TestCaseName;
+                    runningFixtureName = dataMessage.FixtureName;
+                    runningTestCase = FindTestCase(runningTestCaseName, runningFixtureName);
+                    Console.WriteLine("Running {0} in {1}", runningTestCaseName, runningFixtureName);
+
+                    watch.Reset();
+                    watch.Start();
+                }
+            }
+        }
+
+        private ITestData FindTestCase(string testCaseName, string fixtureName)
+        {
+            var tests = GetRunnableTests().Where(x => string.CompareOrdinal(x.Name, testCaseName) == 0 &&
+                            string.CompareOrdinal(x.Fixture.Name, fixtureName) == 0);
+            return tests.First();
+        }
+
+        private static testsuiteType CreateTestSuiteType(string suiteName)
+        {
+            return new testsuiteType
+            {
+                name = suiteName,
+                description = "Unit tests in Revit.",
+                time = "0.0",
+                type = "TestFixture",
+                result = "Success",
+                executed = "True",
+                results = new resultsType { Items = new object[] { } }
+            };
+        }
+
+        private static resultType GetInitializedResultType(string testAssembly)
+        {
+            var result = new resultType
+                                {
+                                    name = testAssembly,
+                                    testsuite = CreateTestSuiteType("DynamoTestFrameworkTests")
+                                };
+
+            result.date = DateTime.Now.ToString("yyyy-MM-dd");
+            result.time = DateTime.Now.ToString("HH:mm:ss");
+            result.failures = 0;
+            result.ignored = 0;
+            result.notrun = 0;
+            result.errors = 0;
+            result.skipped = 0;
+            result.inconclusive = 0;
+            result.invalid = 0;
+
+            return result;
         }
 
         private void OnInitialized()
@@ -1063,15 +1268,18 @@ namespace RTF.Framework
             }
         }
 
-        private void InitializeJournal(string path)
+        private void InitializeJournal(string path, int port)
         {
             if (journalInitialized) return;
 
             using (var tw = new StreamWriter(path, false))
             {
-                var journal = @"'" +
-                              "Dim Jrn \n" +
-                              "Set Jrn = CrsJournalScript \n";
+                var journal = String.Format(@"'" +
+                                             "Dim Jrn \n" +
+                                             "Set Jrn = CrsJournalScript \n" +
+                                             "Jrn.RibbonEvent \"Execute external command:{0}:{1}\" \n" +
+                                             "Jrn.Data \"APIStringStringMapJournalData\", 1, \"Port\", \"{2}\" \n",
+                                             ClientStartPluginGuid, ClientStartPluginClass, port);
 
                 tw.Write(journal);
                 tw.Flush();
@@ -1104,7 +1312,9 @@ namespace RTF.Framework
 
             using (var tw = new StreamWriter(path, true))
             {
-                var journal = "Jrn.Command \"SystemMenu\" , \"Quit the application; prompts to save projects , ID_APP_EXIT\"";
+                var journal = String.Format("Jrn.RibbonEvent \"Execute external command:{0}:{1}\" \n" +
+                                            "Jrn.Command \"SystemMenu\" , \"Quit the application; prompts to save projects , ID_APP_EXIT\"",
+                              ClientEndPluginGuid, ClientEndPluginClass);
 
                 tw.Write(journal);
                 tw.Flush();
@@ -1204,7 +1414,7 @@ namespace RTF.Framework
 
                 if (continuous)
                 {
-                    InitializeJournal(journalPath);
+                    InitializeJournal(journalPath, RevitTestServer.Instance.Port);
                     AddToJournal(journalPath, td.Name, td.Fixture.Name, td.Fixture.Assembly.Path, Results, td.ModelPath);
                 }
                 else
@@ -1280,8 +1490,28 @@ namespace RTF.Framework
                     "<VendorDescription>Dynamo</VendorDescription>\n" +
                     "</AddIn>\n" +
 
+                    "<AddIn Type=\"Command\">\n" +
+                    "<Name>Start Test Framework Client</Name>\n" +
+                    "<Assembly>\"{0}\"</Assembly>\n" +
+                    "<AddInId>{5}</AddInId>\n" +
+                    "<FullClassName>{6}</FullClassName>\n" +
+                    "<VendorId>Dynamo</VendorId>\n" +
+                    "<VendorDescription>Dynamo</VendorDescription>\n" +
+                    "</AddIn>\n" +
+
+                    "<AddIn Type=\"Command\">\n" +
+                    "<Name>End Test Framework Client</Name>\n" +
+                    "<Assembly>\"{0}\"</Assembly>\n" +
+                    "<AddInId>{7}</AddInId>\n" +
+                    "<FullClassName>{8}</FullClassName>\n" +
+                    "<VendorId>Dynamo</VendorId>\n" +
+                    "<VendorDescription>Dynamo</VendorDescription>\n" +
+                    "</AddIn>\n" +
+
                     "</RevitAddIns>",
-                    assemblyPath, _appGuid, _appClass, _pluginGuid, _pluginClass
+                    assemblyPath, _appGuid, _appClass, _pluginGuid, _pluginClass,
+                    _clientStartPluginGuid, _clientStartPluginClass,
+                    _clientEndPluginGuid, _clientEndPluginClass
                     );
 
                 tw.Write(addin);
@@ -1301,6 +1531,7 @@ namespace RTF.Framework
             data.ResultData.Add(new ResultData() { Message = message, StackTrace = stackTrace });
         }
 
+        #region XML reading and writing
         public static resultType TryParseResultsOrEmitError(string resultsPath)
         {
             try
@@ -1325,22 +1556,9 @@ namespace RTF.Framework
             {
                 td.ResultData.Clear();
 
-                //find our results in the results
-                var ourSuite =
-                    results.testsuite.results.Items
-                        .Cast<testsuiteType>()
-                        .FirstOrDefault(s => s.name == td.Fixture.Name);
+                var ourTests = FindOutTestCasesRelatedToTestData(results, td);
 
-                if (ourSuite == null)
-                {
-                    return;
-                }
-
-                // parameterized tests will have multiple results
-                var ourTests = ourSuite.results.Items
-                    .Cast<testcaseType>().Where(t => t.name.Contains(td.Name));
-
-                if (!ourTests.Any())
+                if (ourTests==null || !ourTests.Any())
                 {
                     return;
                 }
@@ -1360,6 +1578,9 @@ namespace RTF.Framework
                             break;
                         case "Ignored":
                             td.TestStatus = TestStatus.Ignored;
+                            break;
+                        case "Timedout":
+                            td.TestStatus = TestStatus.TimedOut;
                             break;
                         case "Inconclusive":
                             td.TestStatus = TestStatus.Inconclusive;
@@ -1390,6 +1611,98 @@ namespace RTF.Framework
             }
 
         }
+
+        public static void WriteTestResultForTestCases(IEnumerable<ITestData> data, string resultsPath, string testAssembly)
+        {
+            var results = TryParseResultsOrEmitError(resultsPath);
+            if (results == null)
+            {
+                // In case, there is no other test case which has run yet
+                results = GetInitializedResultType(testAssembly);
+            }
+
+            List<ITestData> timedoutTests = new List<ITestData>();
+            foreach (var td in data)
+            {
+                if (td.TestStatus == TestStatus.TimedOut)
+                {
+                    timedoutTests.Add(td);
+                }
+            }
+
+            foreach (var td in timedoutTests)
+            {
+                var tests = FindOutTestCasesRelatedToTestData(results, td);
+                if (tests != null && tests.Any())
+                {
+                    // update the test result
+                    foreach (var test in tests)
+                    {
+                        test.executed = "True";
+                        test.success = "False";
+                        test.result = "Timedout";
+                    }
+                }
+                else
+                {
+                    var suite =
+                        results.testsuite.results.Items
+                            .Cast<testsuiteType>()
+                            .FirstOrDefault(s => s.name == td.Fixture.Name);
+
+                    // To expand the existing array, for now it is to create a new array.
+                    // We need to find a way to replace array with list.
+                    if (suite == null)
+                    {
+                        var subSuite = CreateTestSuiteType(td.Fixture.Name);
+                        int newSize = results.testsuite.results.Items.Length + 1;
+                        object[] newArray = new object[newSize];
+                        Array.Copy(results.testsuite.results.Items, newArray, newSize - 1);
+                        newArray[newSize - 1] = subSuite;
+                        results.testsuite.results.Items = newArray;
+                        suite = subSuite;
+                    }
+
+                    int size = suite.results.Items.Length + 1;
+                    object[] array = new object[size];
+                    Array.Copy(suite.results.Items, array, size - 1);
+                    array[size - 1] = new testcaseType() { name = td.Name, executed = "True", success = "False", result = "Timedout" };
+                    suite.results.Items = array;
+                }
+            }
+
+            //update the file
+            var serializer = new XmlSerializer(typeof(resultType));
+            var dir = Path.GetDirectoryName(resultsPath);
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            using (var tw = XmlWriter.Create(resultsPath, new XmlWriterSettings() { Indent = true }))
+            {
+                tw.WriteComment("This file represents the results of running a test suite");
+                var ns = new XmlSerializerNamespaces();
+                ns.Add("", "");
+                serializer.Serialize(tw, results, ns);
+            }
+        }
+
+        private static IEnumerable<testcaseType> FindOutTestCasesRelatedToTestData(resultType results, ITestData td)
+        {
+            var ourSuite =
+                results.testsuite.results.Items
+                    .Cast<testsuiteType>()
+                    .FirstOrDefault(s => s.name == td.Fixture.Name);
+
+            if (ourSuite == null)
+            {
+                return null;
+            }
+
+            // parameterized tests will have multiple results
+            return ourSuite.results.Items.Cast<testcaseType>()
+                .Where(t => string.CompareOrdinal(t.name, td.Name) == 0);
+        }
+
+        #endregion
 
         public virtual IList<IAssemblyData> ReadAssembly(string assemblyPath, string workingDirectory, GroupingType groupType, bool isTesting)
         {

--- a/src/Framework/Runner/Runner.csproj
+++ b/src/Framework/Runner/Runner.csproj
@@ -62,6 +62,7 @@
     </Compile>
     <Compile Include="ObservableCollectionExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RevitTestServer.cs" />
     <Compile Include="Runner.cs" />
     <Compile Include="RunnerSetupData.cs" />
     <Compile Include="TestResultDeserializer.cs" />


### PR DESCRIPTION
### Purpose

When running test cases continuously, it may get issues like:
1). There may be one test case which cause a crash;
2). There may be one test case which introduces an infinite loop;
3). Upon running one test case, the memory consumption may be too high;
(The 3rd case is not addressed in this pull request here because right now the memory consumption is acceptable which will not block the test cases)

For these cases, originally, the test application won't know the situation and does not know how to solve them. Thus if one test case has one of the mentioned issue, the result of the whole test cases will be impacted.

In this implementation, we will try to introduce a mechanism to monitor the running process through socket communication. The test application will keep an eye on what's going on in the main application. If the main application hangs, it will kill the process and record the culprit and continue running the remaining test cases.

### Implementation

In the runner, a server will be constructed to listen to reports which may be sent back from the main application. In the RTFRevit addin, a client side will be constructed which will send message to the server.
![image](https://cloud.githubusercontent.com/assets/5584246/9989633/d375c41e-608c-11e5-8154-8778b9a9643a.png)

The original journal file for all test cases will be prepended with an RTFClientStartCmd which will pass port number to the client through journaling data. An RTFClientEndCmd will be appended to identify that the client has completed running test cases. These two new commands will be implemented in the RTFRevit addin.

A class Message is defined to be passed from client to server. This class is used to contain data like status information, or test case information to be passed. It has two derived classes: DataMessage and ControlMessage. DataMessage is used to pass test case information and ControlMessage is used to pass status information. The Message classes can be serialized into and deserialized from byte arrays. 

Each message has a header to identify the length of the message. Each message will also has a ID which will increase automatically when a new message is created. The length in the header will first be read and the corresponding count of bytes will be attempted to be converted to a message. If the conversion failed or the message ID has not increased by one. This means there are something wrong. (The bytes will be assumed to be little-endian)
![image](https://cloud.githubusercontent.com/assets/5584246/9989895/149761f8-608f-11e5-9ab6-21fc572d507e.png)

### Test
A sample test assembly has been implemented which has one test case to simulate a crash and one to simulate an infinite loop. Here is the test result:
![image](https://cloud.githubusercontent.com/assets/5584246/9990121/36d13d78-6091-11e5-9f20-c898a5c142ae.png)

The two which have errors are identified and we can see from the text output the journaling file has been recreated between Test4_Infiniteloop and Test5.

### Reviewers
@ikeough 
