### PR TITLE
Update FindRevit() method to return all installed Revit products 

### DIFF
--- a/src/Framework/Runner/RunnerSetupData.cs
+++ b/src/Framework/Runner/RunnerSetupData.cs
@@ -41,10 +41,12 @@ namespace RTF.Framework
         {
             var products = RevitProductUtility.GetAllInstalledRevitProducts();
 
-            if (products.Any())
-            {
-                products = products.Where(x => x.Version == RevitVersion.Revit2015 || x.Version==RevitVersion.Revit2016 || x.Version==RevitVersion.Revit2017).ToList();
-            }
+            //For now let's return all the installed products. Sometimes the products in development
+            //might return Unknown version.
+            //if (products.Any())
+            //{
+            //    products = products.Where(x => x.Version == RevitVersion.Revit2015 || x.Version==RevitVersion.Revit2016 || x.Version==RevitVersion.Revit2017).ToList();
+            //}
 
             return products;
         }


### PR DESCRIPTION
### Purpose:

RevitTestFramework GUI is not able to detect Revit 2017, becuase it's not returning correct product version. Hence update FindRevit() method to return all Revit products.

### Reviewers

- [x] @ikeough 