### PR TITLE
Small Improvement to prevent RTF go into wierd state

### DIFF
--- a/src/Framework/Runner/Runner.cs
+++ b/src/Framework/Runner/Runner.cs
@@ -1697,7 +1697,7 @@ namespace RTF.Framework
                     .Cast<testsuiteType>()
                     .FirstOrDefault(s => s.name == td.Fixture.Name);
 
-            if (ourSuite == null)
+            if (ourSuite == null || (ourSuite.results.Items == null))
             {
                 return null;
             }


### PR DESCRIPTION
Cherry pick from R2018 branch. I have seen RTF churn at the following line because missing such null check. Small Improvement to prevent RTF go into wierd state.

FYI: @mjkkirschner