### PR TITLE
Use Dynamo.config to resolve assembly

### DIFF
--- a/src/Framework/RevitTestFramework/RevitTestFrameworkTypes.csproj
+++ b/src/Framework/RevitTestFramework/RevitTestFrameworkTypes.csproj
@@ -46,6 +46,7 @@
       <HintPath>..\..\..\lib\NUnit\nunit.core.interfaces.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes.cs" />


### PR DESCRIPTION
### Purpose:

This PR allows the Test framework to resolve DynamoCore dlls, while loading test dlls using Dynamo.config file if it's present to specify DynamoRuntime location as per https://github.com/DynamoDS/Dynamo/pull/7417

### Reviewer
@Randy-Ma 