### PR TITLE
Added a fix for Issue #70

### DIFF
--- a/src/Framework/Runner/AddinHelpers.cs
+++ b/src/Framework/Runner/AddinHelpers.cs
@@ -20,9 +20,12 @@ namespace RTF.Framework
         public static void FullyQualifyAddinPaths (FileInfo copiedAddinFile, FileInfo originalAddin)
         {
             XmlDocument doc = new XmlDocument();
-            doc.Load(copiedAddinFile.FullName);
+            using (StreamReader streamReader = new StreamReader(copiedAddinFile.FullName, true))
+            {
+                doc.Load(streamReader);
+            }
 
-            foreach(XmlElement addinElement in doc.DocumentElement.ChildNodes)
+            foreach (XmlElement addinElement in doc.DocumentElement.ChildNodes)
             {
                 //if this element is an addin attempt to make the assembly path a full path
              if (addinElement.LocalName != "AddIn")


### PR DESCRIPTION
RevitTestFramework fails to Run If an Addin manifest is encoded in UTF-16. When run from the console using RevitTestFrameworkConsole.exe, the error message is "There is no Unicode byte order mark. Cannot switch to Unicode." There is no error message shown in the GUI, but it still fails.

We can solve this problem by using StreamReader to automatically detect the encoding of the .addin manifest. Once loaded, we can pass the StreamReader directly to XmlDocument. This works for both UTF-8 and UTF-16 manifests. 