### PR TITLE
make command line interpreter use copyaddin flag

### DIFF
--- a/src/Framework/Runner/Interfaces.cs
+++ b/src/Framework/Runner/Interfaces.cs
@@ -80,6 +80,7 @@ namespace RTF.Framework
         bool CleanUp { get; set; }
         bool Continuous { get; set; }
         bool IsDebug { get; set; }
+        bool CopyAddin { get; set; }
         GroupingType GroupingType { get; set; }
         int Timeout { get; set; }
         bool IsTesting { get; set; }

--- a/src/Framework/Runner/Runner.cs
+++ b/src/Framework/Runner/Runner.cs
@@ -423,6 +423,7 @@ namespace RTF.Framework
             CleanUp = setupData.CleanUp;
             Continuous = setupData.Continuous;
             IsDebug = setupData.IsDebug;
+            CopyAddins = setupData.CopyAddin;
             GroupingType = setupData.GroupingType;
             Timeout = setupData.Timeout;
             IsTesting = setupData.IsTesting;


### PR DESCRIPTION
While trying to use this from the command line I realized that the --copyAddin flag was always it's default value, which was true.  I have many addin installed on my machine, and some .addin xml encoding was causing the test to hang, so I needed to be able to actually have the test framework NOT copy addin files.
figured I'd share the change... hope I'm doing this right :-)