### PR TITLE
Increase Test Timeout

### DIFF
--- a/src/Framework/Runner/Runner.cs
+++ b/src/Framework/Runner/Runner.cs
@@ -54,7 +54,7 @@ namespace RTF.Framework
         private bool _gui = true;
         private string _revitPath;
         private bool _copyAddins = true;
-        private int _timeout = 120000;
+        private int _timeout = 160000;
         private bool _concat;
         private List<string> _copiedAddins = new List<string>();
         private string _assemblyPath;


### PR DESCRIPTION
Increase default individual test timeout from 2min to 2min40s as part of https://github.com/DynamoDS/DynamoRevit/pull/1826