### PR TITLE
Update RevitAPI reference Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ This repo maintains branches to track the two most recently released versions of
 When testing, you should run the version of RTF corresponding to the version of Revit you are running. This will ensure that tests you have created, based on one Revit API, will correspond to the version of the API running on Revit.  
 However, the current version of RTF works and can be used to test within Revit 2017, 2018, and 2019.
 
+## Build Issues
+
+If you want to build RTF on a machine that don't have a Revit installed, you can put the Revit API related dlls under folder lib\Revit $(RevitVersionNumber)\net452 which was defined in CS.props. The build can be success, but if you want to run RTF, you still need a machine with Revit installed.
+
 ## License
 
 Copyright 2014 Autodesk

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This repo maintains branches to track the two most recently released versions of
 When testing, you should run the version of RTF corresponding to the version of Revit you are running. This will ensure that tests you have created, based on one Revit API, will correspond to the version of the API running on Revit.  
 However, the current version of RTF works and can be used to test within Revit 2017, 2018, and 2019.
 
-## Build Issues
+## Build Configurations
 
 If you want to build RTF on a machine that don't have a Revit installed, you can put the Revit API related dlls under folder lib\Revit $(RevitVersionNumber)\net452 which was defined in CS.props. The build can be success, but if you want to run RTF, you still need a machine with Revit installed.
 

--- a/src/Applications/RTFRevit/RTFRevit.csproj
+++ b/src/Applications/RTFRevit/RTFRevit.csproj
@@ -40,9 +40,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AdWindows, Version=2015.11.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Revit-2017.1.1-x64.Base.2.0.0\lib\net452\AdWindows.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="AdWindows">
+      <HintPath>$(REVITAPI)\AdWindows.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=3.1.2.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Costura.Fody.3.1.2\lib\net46\Costura.dll</HintPath>
@@ -54,25 +53,20 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\lib\NUnit\nunit.core.interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAPI, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Revit-2017.1.1-x64.Base.2.0.0\lib\net452\RevitAPI.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="RevitAPI">
+      <HintPath>$(REVITAPI)\RevitAPI.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAPIIFC, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Revit-2017.1.1-x64.Base.2.0.0\lib\net452\RevitAPIIFC.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="RevitAPIIFC">
+      <HintPath>$(REVITAPI)\RevitAPIIFC.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAPIMacros, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Revit-2017.1.1-x64.Base.2.0.0\lib\net452\RevitAPIMacros.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="RevitAPIMacros">
+      <HintPath>$(REVITAPI)\RevitAPIMacros.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAPIUI, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Revit-2017.1.1-x64.Base.2.0.0\lib\net452\RevitAPIUI.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="RevitAPIUI">
+      <HintPath>$(REVITAPI)\RevitAPIUI.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAPIUIMacros, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Revit-2017.1.1-x64.Base.2.0.0\lib\net452\RevitAPIUIMacros.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="RevitAPIUIMacros">
+      <HintPath>$(REVITAPI)\RevitAPIUIMacros.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -100,7 +94,9 @@
     <None Include="NUnitResultTypes.xsd">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Applications/RTFRevit/packages.config
+++ b/src/Applications/RTFRevit/packages.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="Costura.Fody" version="3.1.2" targetFramework="net47" />
   <package id="Fody" version="3.2.4" targetFramework="net47" developmentDependency="true" />
-  <package id="Revit-2017.1.1-x64.Base" version="2.0.0" targetFramework="net47" />
 </packages>

--- a/src/Applications/RevitTestFrameworkGUI/RevitTestFrameworkGUI.csproj
+++ b/src/Applications/RevitTestFrameworkGUI/RevitTestFrameworkGUI.csproj
@@ -52,8 +52,8 @@
     <Reference Include="Microsoft.Practices.Prism">
       <HintPath>..\..\..\lib\Microsoft.Practices.Prism.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAddInUtility, Version=17.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Revit-2017.1.1x64-Utilities.1.0.0\lib\net452\RevitAddInUtility.dll</HintPath>
+    <Reference Include="RevitAddInUtility">
+      <HintPath>$(REVITAPI)\RevitAddInUtility.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Windows.Forms" />
@@ -104,7 +104,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/src/Applications/RevitTestFrameworkGUI/packages.config
+++ b/src/Applications/RevitTestFrameworkGUI/packages.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="Costura.Fody" version="3.1.2" targetFramework="net47" />
   <package id="Fody" version="3.2.4" targetFramework="net47" developmentDependency="true" />
-  <package id="Revit-2017.1.1x64-Utilities" version="1.0.0" targetFramework="net47" />
 </packages>

--- a/src/Config/CS.props
+++ b/src/Config/CS.props
@@ -3,10 +3,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <RevitVersionNumber Condition=" '$(RevitVersionNumber)' == '' ">2019</RevitVersionNumber>
     <OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\$(Platform)\$(Configuration)</OutputPath>
     <NunitPath Condition=" '$(NunitPath)' == '' ">$(SolutionDir)..\lib\NUnit</NunitPath>
-    <REVITAPI  Condition=" '$(REVITAPI)' == '' ">C:\Program Files\Autodesk\Revit Architecture 2019</REVITAPI>
-    <REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit 2019</REVITAPI>
+    <REVITAPI Condition=" '$(REVITAPI)' == '' ">$(SolutionDir)..\lib\Revit $(RevitVersionNumber)\net452</REVITAPI>
+    <REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit Architecture $(RevitVersionNumber)</REVITAPI>
+    <REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit $(RevitVersionNumber)</REVITAPI>
 	<REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit Preview Release</REVITAPI>
     <BaseIntermediateOutputPath>$(OutputPath)\int\</BaseIntermediateOutputPath>
     <DebugSymbols>true</DebugSymbols>
@@ -19,10 +21,12 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <RevitVersionNumber Condition=" '$(RevitVersionNumber)' == '' ">2019</RevitVersionNumber>
     <OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\$(Platform)\$(Configuration)</OutputPath>
     <NunitPath Condition=" '$(NunitPath)' == '' ">$(SolutionDir)..\lib\NUnit</NunitPath>
-    <REVITAPI  Condition=" '$(REVITAPI)' == '' ">C:\Program Files\Autodesk\Revit Architecture 2019</REVITAPI>
-    <REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit 2019</REVITAPI>
+    <REVITAPI Condition=" '$(REVITAPI)' == '' ">$(SolutionDir)..\lib\Revit $(RevitVersionNumber)\net452</REVITAPI>
+    <REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit Architecture $(RevitVersionNumber)</REVITAPI>
+    <REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit $(RevitVersionNumber)</REVITAPI>
 	<REVITAPI Condition=" !Exists('$(REVITAPI)') ">C:\Program Files\Autodesk\Revit Preview Release</REVITAPI>
     <BaseIntermediateOutputPath>$(OutputPath)\int\</BaseIntermediateOutputPath>
     <DebugType>pdbonly</DebugType>

--- a/src/Framework/Runner/Runner.csproj
+++ b/src/Framework/Runner/Runner.csproj
@@ -54,8 +54,8 @@
       <HintPath>..\..\..\lib\NUnit\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
-    <Reference Include="RevitAddInUtility, Version=17.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Revit-2017.1.1x64-Utilities.1.0.0\lib\net452\RevitAddInUtility.dll</HintPath>
+    <Reference Include="RevitAddInUtility">
+      <HintPath>$(REVITAPI)\RevitAddInUtility.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -81,7 +81,9 @@
     <None Include="NUnitResultTypes.xsd">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RevitTestFramework\RevitTestFrameworkTypes.csproj">

--- a/src/Framework/Runner/packages.config
+++ b/src/Framework/Runner/packages.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="Costura.Fody" version="3.1.2" targetFramework="net47" />
   <package id="Fody" version="3.2.4" targetFramework="net47" developmentDependency="true" />
-  <package id="Revit-2017.1.1x64-Utilities" version="1.0.0" targetFramework="net47" />
 </packages>

--- a/src/Tests/RunnerTests/RunnerTests.csproj
+++ b/src/Tests/RunnerTests/RunnerTests.csproj
@@ -43,8 +43,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\lib\NUnit\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAddInUtility, Version=17.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Revit-2017.1.1x64-Utilities.1.0.0\lib\net452\RevitAddInUtility.dll</HintPath>
+    <Reference Include="RevitAddInUtility">
+      <HintPath>$(REVITAPI)\RevitAddInUtility.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -59,9 +59,6 @@
       <Project>{4a25bb46-081a-4acd-9c38-297cd800550f}</Project>
       <Name>Runner</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Tests/RunnerTests/packages.config
+++ b/src/Tests/RunnerTests/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Revit-2017.1.1x64-Utilities" version="1.0.0" targetFramework="net47" />
-</packages>

--- a/src/Tests/Samples/SampleTests.csproj
+++ b/src/Tests/Samples/SampleTests.csproj
@@ -36,33 +36,27 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AdWindows, Version=2015.11.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Revit-2017.1.1-x64.Base.2.0.0\lib\net452\AdWindows.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="AdWindows">
+      <HintPath>$(REVITAPI)\AdWindows.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\lib\NUnit\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAPI, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Revit-2017.1.1-x64.Base.2.0.0\lib\net452\RevitAPI.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="RevitAPI">
+      <HintPath>$(REVITAPI)\RevitAPI.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAPIIFC, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Revit-2017.1.1-x64.Base.2.0.0\lib\net452\RevitAPIIFC.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="RevitAPIIFC">
+      <HintPath>$(REVITAPI)\RevitAPIIFC.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAPIMacros, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Revit-2017.1.1-x64.Base.2.0.0\lib\net452\RevitAPIMacros.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="RevitAPIMacros">
+      <HintPath>$(REVITAPI)\RevitAPIMacros.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAPIUI, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Revit-2017.1.1-x64.Base.2.0.0\lib\net452\RevitAPIUI.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="RevitAPIUI">
+      <HintPath>$(REVITAPI)\RevitAPIUI.dll</HintPath>
     </Reference>
-    <Reference Include="RevitAPIUIMacros, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\..\packages\Revit-2017.1.1-x64.Base.2.0.0\lib\net452\RevitAPIUIMacros.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="RevitAPIUIMacros">
+      <HintPath>$(REVITAPI)\RevitAPIUIMacros.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -82,7 +76,6 @@
     <Content Include="SampleTests.dll.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Applications\RTFRevit\RTFRevit.csproj">

--- a/src/Tests/Samples/packages.config
+++ b/src/Tests/Samples/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Revit-2017.1.1-x64.Base" version="2.0.0" targetFramework="net47" />
-</packages>


### PR DESCRIPTION
Description
Update RevitAPI reference Path. If you don't want to use installed RevitAPI, you can create a lib folder lib\Revit $(RevitVersionNumber)\net452 and put in RevitAPI libraries which you want to use.

Reviewer
@AndyDu1985 

FYI
@marchello2000 @QilongTang @mjkkirschner 