### PR TITLE
Add error message for revit addin folder

### DIFF
--- a/src/Framework/Runner/Runner.cs
+++ b/src/Framework/Runner/Runner.cs
@@ -430,7 +430,7 @@ namespace RTF.Framework
                     Console.WriteLine("ERROR: Revit Addin Folder \"{0}\" don't exist.", revitAddinFolder);
                     return false;
                 }
-                var files = Directory.GetFiles(GetRevitAddinFolder());
+                var files = Directory.GetFiles(revitAddinFolder);
                 foreach (var file in files)
                 {
                     if (file.EndsWith(".addin", StringComparison.OrdinalIgnoreCase))

--- a/src/Framework/Runner/Runner.cs
+++ b/src/Framework/Runner/Runner.cs
@@ -424,6 +424,12 @@ namespace RTF.Framework
             // so that they can be loaded.
             if (CopyAddins)
             {
+                var revitAddinFolder = GetRevitAddinFolder();
+                if(!Directory.Exists(revitAddinFolder))
+                {
+                    Console.WriteLine("ERROR: Revit Addin Folder \"{0}\" don't exist.", revitAddinFolder);
+                    return false;
+                }
                 var files = Directory.GetFiles(GetRevitAddinFolder());
                 foreach (var file in files)
                 {


### PR DESCRIPTION
RTF hang when Revit Addin Folder don't exist.
